### PR TITLE
Build action for NuGet Package and Artifacts

### DIFF
--- a/.github/workflows/commonBuildAndTest.yml
+++ b/.github/workflows/commonBuildAndTest.yml
@@ -35,8 +35,12 @@ jobs:
       run: dotnet build --configuration Release --no-restore
       working-directory: src
 
+    - name: Test
+      run: dotnet test --no-restore --verbosity normal
+      working-directory: src
+    
     - name: Publish OctoConsole
-      run: dotnet publish OctoConsole/OctoConsole.csproj --configuration Release --output ./artifacts/octoconsole/ -p:Version=${{ steps.tag-action.outputs.new_tag }} --no-restore
+      run: dotnet publish src/OctoConsole/OctoConsole.csproj --configuration Release --output ./artifacts/octoconsole/ -p:Version=${{ steps.tag-action.outputs.new_tag }} --no-restore
 
     - name: Upload OctoConsole
       uses: actions/upload-artifact@v2
@@ -45,7 +49,7 @@ jobs:
         path: ./artifacts/octoconsole/
 
     - name: Publish OctoPatch.DesktopClient
-      run: dotnet publish OctoPatch.DesktopClient/OctoPatch.DesktopClient.csproj --configuration Release --output ./artifacts/desktopclient/ -p:Version=${{ steps.tag-action.outputs.new_tag }} --no-restore
+      run: dotnet publish src/OctoPatch.DesktopClient/OctoPatch.DesktopClient.csproj --configuration Release --output ./artifacts/desktopclient/ -p:Version=${{ steps.tag-action.outputs.new_tag }} --no-restore
 
     - name: Upload OctoPatch.DesktopClient
       uses: actions/upload-artifact@v2
@@ -53,12 +57,8 @@ jobs:
         name: OctoPatch.DesktopClient
         path: ./artifacts/desktopclient/
 
-    - name: Test
-      run: dotnet test --no-restore --verbosity normal
-      working-directory: src
-
     - name: Create NuGet Package
-      run: dotnet pack OctoPatch/OctoPatch.csproj --configuration Release --output ./artifacts/nuget/ -p:Version=${{ steps.tag-action.outputs.new_tag }} --no-restore
+      run: dotnet pack src/OctoPatch/OctoPatch.csproj --configuration Release --output ./artifacts/nuget/ -p:Version=${{ steps.tag-action.outputs.new_tag }} --no-restore
 
     # - name: Publish NuGet Package
     #   run: dotnet nuget push ./artifacts/nuget/*.nupkg -k ${{ secrets.NUGET-API-KEY }} -s https://api.nuget.org/v3/index.json

--- a/.github/workflows/commonBuildAndTest.yml
+++ b/.github/workflows/commonBuildAndTest.yml
@@ -8,21 +8,57 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
+    
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0 # set the fetch-depth for actions/checkout@master to be sure you retrieve all commits to look for the semver commit message.
+
+    - name: Bump version and push tag
+      id: tag-action
+      uses: anothrNick/github-tag-action@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.301
+        dotnet-version: '3.1.x'
+
     - name: Install dependencies
       run: dotnet restore
       working-directory: src
+
     - name: Build
       run: dotnet build --configuration Release --no-restore
       working-directory: src
+
+    - name: Publish OctoConsole
+      run: dotnet publish OctoConsole/OctoConsole.csproj --configuration Release --output ./artifacts/octoconsole/ -p:Version=${{ steps.tag-action.outputs.new_tag }} --no-restore
+
+    - name: Upload OctoConsole
+      uses: actions/upload-artifact@v2
+      with:
+        name: OctoConsole
+        path: ./artifacts/octoconsole/
+
+    - name: Publish OctoPatch.DesktopClient
+      run: dotnet publish OctoPatch.DesktopClient/OctoPatch.DesktopClient.csproj --configuration Release --output ./artifacts/desktopclient/ -p:Version=${{ steps.tag-action.outputs.new_tag }} --no-restore
+
+    - name: Upload OctoPatch.DesktopClient
+      uses: actions/upload-artifact@v2
+      with:
+        name: OctoPatch.DesktopClient
+        path: ./artifacts/desktopclient/
+
     - name: Test
       run: dotnet test --no-restore --verbosity normal
       working-directory: src
+
+    - name: Create NuGet Package
+      run: dotnet pack OctoPatch/OctoPatch.csproj --configuration Release --output ./artifacts/nuget/ -p:Version=${{ steps.tag-action.outputs.new_tag }} --no-restore
+
+    # - name: Publish NuGet Package
+    #   run: dotnet nuget push ./artifacts/nuget/*.nupkg -k ${{ secrets.NUGET-API-KEY }} -s https://api.nuget.org/v3/index.json

--- a/.github/workflows/commonBuildAndTest.yml
+++ b/.github/workflows/commonBuildAndTest.yml
@@ -55,7 +55,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@master
+      uses: actions/checkout@v2
 
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1

--- a/.github/workflows/commonBuildAndTest.yml
+++ b/.github/workflows/commonBuildAndTest.yml
@@ -47,7 +47,7 @@ jobs:
       run: dotnet pack src/OctoPatch/OctoPatch.csproj --configuration Release --output ./artifacts/nuget/ -p:Version=${{ steps.tag-action.outputs.new_tag }} --no-restore
 
     - name: Publish NuGet Package
-      run: dotnet nuget push ./artifacts/nuget/*.nupkg -k ${{ secrets.NUGET-API-KEY }} -s https://api.nuget.org/v3/index.json
+      run: dotnet nuget push ./artifacts/nuget/*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
 
   package:
     needs: [build]

--- a/.github/workflows/commonBuildAndTest.yml
+++ b/.github/workflows/commonBuildAndTest.yml
@@ -46,8 +46,8 @@ jobs:
     - name: Create NuGet Package
       run: dotnet pack src/OctoPatch/OctoPatch.csproj --configuration Release --output ./artifacts/nuget/ -p:Version=${{ steps.tag-action.outputs.new_tag }} --no-restore
 
-    # - name: Publish NuGet Package
-    #   run: dotnet nuget push ./artifacts/nuget/*.nupkg -k ${{ secrets.NUGET-API-KEY }} -s https://api.nuget.org/v3/index.json
+    - name: Publish NuGet Package
+      run: dotnet nuget push ./artifacts/nuget/*.nupkg -k ${{ secrets.NUGET-API-KEY }} -s https://api.nuget.org/v3/index.json
 
   package:
     needs: [build]

--- a/.github/workflows/commonBuildAndTest.yml
+++ b/.github/workflows/commonBuildAndTest.yml
@@ -21,6 +21,7 @@ jobs:
       uses: anothrNick/github-tag-action@master
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        DEFAULT_BUMP: patch
 
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
@@ -48,14 +49,14 @@ jobs:
         name: OctoConsole
         path: ./artifacts/octoconsole/
 
-    - name: Publish OctoPatch.DesktopClient
-      run: dotnet publish src/OctoPatch.DesktopClient/OctoPatch.DesktopClient.csproj --configuration Release --output ./artifacts/desktopclient/ -p:Version=${{ steps.tag-action.outputs.new_tag }} --no-restore
+    # - name: Publish OctoPatch.DesktopClient
+    #   run: dotnet publish src/OctoPatch.DesktopClient/OctoPatch.DesktopClient.csproj --configuration Release --output ./artifacts/desktopclient/ -p:Version=${{ steps.tag-action.outputs.new_tag }} --no-restore
 
-    - name: Upload OctoPatch.DesktopClient
-      uses: actions/upload-artifact@v2
-      with:
-        name: OctoPatch.DesktopClient
-        path: ./artifacts/desktopclient/
+    # - name: Upload OctoPatch.DesktopClient
+    #   uses: actions/upload-artifact@v2
+    #   with:
+    #     name: OctoPatch.DesktopClient
+    #     path: ./artifacts/desktopclient/
 
     - name: Create NuGet Package
       run: dotnet pack src/OctoPatch/OctoPatch.csproj --configuration Release --output ./artifacts/nuget/ -p:Version=${{ steps.tag-action.outputs.new_tag }} --no-restore

--- a/.github/workflows/commonBuildAndTest.yml
+++ b/.github/workflows/commonBuildAndTest.yml
@@ -10,6 +10,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     
+    outputs:
+      version: ${{ steps.tag-action.outputs.new_tag }}
+
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -39,9 +42,28 @@ jobs:
     - name: Test
       run: dotnet test --no-restore --verbosity normal
       working-directory: src
-    
+
+    - name: Create NuGet Package
+      run: dotnet pack src/OctoPatch/OctoPatch.csproj --configuration Release --output ./artifacts/nuget/ -p:Version=${{ steps.tag-action.outputs.new_tag }} --no-restore
+
+    # - name: Publish NuGet Package
+    #   run: dotnet nuget push ./artifacts/nuget/*.nupkg -k ${{ secrets.NUGET-API-KEY }} -s https://api.nuget.org/v3/index.json
+
+  package:
+    needs: [build]
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '3.1.x'
+
     - name: Publish OctoConsole
-      run: dotnet publish src/OctoConsole/OctoConsole.csproj --configuration Release --output ./artifacts/octoconsole/ -p:Version=${{ steps.tag-action.outputs.new_tag }} --no-restore
+      run: dotnet publish src/OctoConsole/OctoConsole.csproj --configuration Release --runtime win-x86 --output ./artifacts/octoconsole/ -p:Version=${{ needs.build.outputs.version }} --no-restore
 
     - name: Upload OctoConsole
       uses: actions/upload-artifact@v2
@@ -49,17 +71,12 @@ jobs:
         name: OctoConsole
         path: ./artifacts/octoconsole/
 
-    # - name: Publish OctoPatch.DesktopClient
-    #   run: dotnet publish src/OctoPatch.DesktopClient/OctoPatch.DesktopClient.csproj --configuration Release --output ./artifacts/desktopclient/ -p:Version=${{ steps.tag-action.outputs.new_tag }} --no-restore
+    - name: Publish OctoPatch.DesktopClient
+      run: dotnet publish src/OctoPatch.DesktopClient/OctoPatch.DesktopClient.csproj --configuration Release --runtime win-x86 --output ./artifacts/desktopclient/ -p:Version=${{ needs.build.outputs.version }} --no-restore
 
-    # - name: Upload OctoPatch.DesktopClient
-    #   uses: actions/upload-artifact@v2
-    #   with:
-    #     name: OctoPatch.DesktopClient
-    #     path: ./artifacts/desktopclient/
-
-    - name: Create NuGet Package
-      run: dotnet pack src/OctoPatch/OctoPatch.csproj --configuration Release --output ./artifacts/nuget/ -p:Version=${{ steps.tag-action.outputs.new_tag }} --no-restore
-
-    # - name: Publish NuGet Package
-    #   run: dotnet nuget push ./artifacts/nuget/*.nupkg -k ${{ secrets.NUGET-API-KEY }} -s https://api.nuget.org/v3/index.json
+    - name: Upload OctoPatch.DesktopClient
+      uses: actions/upload-artifact@v2
+      with:
+        name: OctoPatch.DesktopClient
+        path: ./artifacts/desktopclient/
+       

--- a/.github/workflows/commonBuildAndTest.yml
+++ b/.github/workflows/commonBuildAndTest.yml
@@ -62,12 +62,8 @@ jobs:
       with:
         dotnet-version: '3.1.x'
 
-    - name: Install dependencies
-      run: dotnet restore
-      working-directory: src
-
     - name: Publish OctoConsole
-      run: dotnet publish src/OctoConsole/OctoConsole.csproj --configuration Release --runtime win-x86 --output ./artifacts/octoconsole/ -p:Version=${{ needs.build.outputs.version }} --no-restore
+      run: dotnet publish src/OctoConsole/OctoConsole.csproj --configuration Release --runtime win-x86 --output ./artifacts/octoconsole/ -p:Version=${{ needs.build.outputs.version }}
 
     - name: Upload OctoConsole
       uses: actions/upload-artifact@v2
@@ -76,7 +72,7 @@ jobs:
         path: ./artifacts/octoconsole/
 
     - name: Publish OctoPatch.DesktopClient
-      run: dotnet publish src/OctoPatch.DesktopClient/OctoPatch.DesktopClient.csproj --configuration Release --runtime win-x86 --output ./artifacts/desktopclient/ -p:Version=${{ needs.build.outputs.version }} --no-restore
+      run: dotnet publish src/OctoPatch.DesktopClient/OctoPatch.DesktopClient.csproj --configuration Release --runtime win-x86 --output ./artifacts/desktopclient/ -p:Version=${{ needs.build.outputs.version }}
 
     - name: Upload OctoPatch.DesktopClient
       uses: actions/upload-artifact@v2

--- a/.github/workflows/commonBuildAndTest.yml
+++ b/.github/workflows/commonBuildAndTest.yml
@@ -62,6 +62,10 @@ jobs:
       with:
         dotnet-version: '3.1.x'
 
+    - name: Install dependencies
+      run: dotnet restore
+      working-directory: src
+
     - name: Publish OctoConsole
       run: dotnet publish src/OctoConsole/OctoConsole.csproj --configuration Release --runtime win-x86 --output ./artifacts/octoconsole/ -p:Version=${{ needs.build.outputs.version }} --no-restore
 

--- a/src/OctoPatch/OctoPatch.csproj
+++ b/src/OctoPatch/OctoPatch.csproj
@@ -2,6 +2,11 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <Authors>Tom Wendel</Authors>
+    <PackageProjectUrl>https://github.com/AusLiebeZumCode/OctoPatch</PackageProjectUrl>
+    <PackageLicenseExpression>https://github.com/AusLiebeZumCode/OctoPatch/blob/master/LICENSE</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/AusLiebeZumCode/OctoPatch</RepositoryUrl>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OctoPatch/OctoPatch.csproj
+++ b/src/OctoPatch/OctoPatch.csproj
@@ -1,13 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>Tom Wendel</Authors>
     <PackageProjectUrl>https://github.com/AusLiebeZumCode/OctoPatch</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/AusLiebeZumCode/OctoPatch/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/AusLiebeZumCode/OctoPatch</RepositoryUrl>
     <PackageProjectUrl>https://github.com/AusLiebeZumCode/OctoPatch</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OctoPatch/OctoPatch.csproj
+++ b/src/OctoPatch/OctoPatch.csproj
@@ -4,8 +4,9 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>Tom Wendel</Authors>
     <PackageProjectUrl>https://github.com/AusLiebeZumCode/OctoPatch</PackageProjectUrl>
-    <PackageLicenseExpression>https://github.com/AusLiebeZumCode/OctoPatch/blob/master/LICENSE</PackageLicenseExpression>
+    <PackageLicenseUrl>https://github.com/AusLiebeZumCode/OctoPatch/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/AusLiebeZumCode/OctoPatch</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/AusLiebeZumCode/OctoPatch</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
   </PropertyGroup>
 


### PR DESCRIPTION
* Automatische Versionierung durch git-tags
  * bei jedem push wird der git-tag um die `patch` Version erhöht (`0.0.1` -> `0.0.2`)
  *  wird in der Commit Nachricht ein `#major`, `#minor`, `#patch` angegeben, so wird die Version dementsprechend erhöht
* `OctoPatch` wird nun als NuGet Paket gebaut und veröffentlicht
  * @tomwendel hierfür bitte in den [Projekteinstellungen](https://github.com/AusLiebeZumCode/OctoPatch/settings/secrets/new) ein neues Secret mit dem Key `NUGET-API-KEY` und deinem `nuget.org` API Key anlegen.
* `OctoConsole` und `OctoPatch.DesktopClient` werden in `Release` `win-x86` gebaut und unter dem jeweiligen Run der Github Action zum herunterladen als `.zip` angeboten

@tomwendel bitte squashen :)
fixes #6 