### PR TITLE
Fügt den DesktopClient zu der Projektmappe hinzu

### DIFF
--- a/.github/workflows/commonBuildAndTest.yml
+++ b/.github/workflows/commonBuildAndTest.yml
@@ -37,19 +37,16 @@ jobs:
         dotnet-version: '3.1.x'
 
     - name: Install dependencies
-      shell: bash
       run: dotnet restore --runtime win-x86 
-      working-directory: ./src/
+      working-directory: src
 
     - name: Build
-      shell: bash
       run: dotnet build --configuration Release --no-restore
-      working-directory: ./src/
+      working-directory: src
 
     - name: Test
-      shell: bash
       run: dotnet test --no-restore --verbosity normal
-      working-directory: ./src/
+      working-directory: src
 
     - name: Create NuGet Package
       run: dotnet pack src/OctoPatch/OctoPatch.csproj --configuration Release --output ./artifacts/nuget/ -p:Version=${{ needs.tag.outputs.version }} --no-restore

--- a/.github/workflows/commonBuildAndTest.yml
+++ b/.github/workflows/commonBuildAndTest.yml
@@ -26,6 +26,11 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         DEFAULT_BUMP: patch
 
+  package:
+    needs: [build]
+    runs-on: windows-latest
+
+    steps:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
@@ -44,23 +49,10 @@ jobs:
       working-directory: src
 
     - name: Create NuGet Package
-      run: dotnet pack src/OctoPatch/OctoPatch.csproj --configuration Release --output ./artifacts/nuget/ -p:Version=${{ steps.tag-action.outputs.new_tag }} --no-restore
+      run: dotnet pack src/OctoPatch/OctoPatch.csproj --configuration Release --output ./artifacts/nuget/ -p:Version=${{ needs.build.outputs.version }} --no-restore
 
     - name: Publish NuGet Package
       run: dotnet nuget push ./artifacts/nuget/*.nupkg -k ${{ secrets.NUGET-API-KEY }} -s https://api.nuget.org/v3/index.json
-
-  package:
-    needs: [build]
-    runs-on: windows-latest
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '3.1.x'
 
     - name: Publish OctoConsole
       run: dotnet publish src/OctoConsole/OctoConsole.csproj --configuration Release --runtime win-x86 --output ./artifacts/octoconsole/ -p:Version=${{ needs.build.outputs.version }}

--- a/.github/workflows/commonBuildAndTest.yml
+++ b/.github/workflows/commonBuildAndTest.yml
@@ -39,17 +39,17 @@ jobs:
     - name: Install dependencies
       shell: bash
       run: dotnet restore --runtime win-x86 
-      working-directory: src
+      working-directory: ./src/
 
     - name: Build
       shell: bash
       run: dotnet build --configuration Release --no-restore
-      working-directory: src
+      working-directory: ./src/
 
     - name: Test
       shell: bash
       run: dotnet test --no-restore --verbosity normal
-      working-directory: src
+      working-directory: ./src/
 
     - name: Create NuGet Package
       run: dotnet pack src/OctoPatch/OctoPatch.csproj --configuration Release --output ./artifacts/nuget/ -p:Version=${{ needs.tag.outputs.version }} --no-restore

--- a/.github/workflows/commonBuildAndTest.yml
+++ b/.github/workflows/commonBuildAndTest.yml
@@ -37,16 +37,19 @@ jobs:
         dotnet-version: '3.1.x'
 
     - name: Install dependencies
+      shell: bash
       run: dotnet restore --runtime win-x86 
-      working-directory: src/
+      working-directory: src
 
     - name: Build
+      shell: bash
       run: dotnet build --configuration Release --no-restore
-      working-directory: src/
+      working-directory: src
 
     - name: Test
+      shell: bash
       run: dotnet test --no-restore --verbosity normal
-      working-directory: src/
+      working-directory: src
 
     - name: Create NuGet Package
       run: dotnet pack src/OctoPatch/OctoPatch.csproj --configuration Release --output ./artifacts/nuget/ -p:Version=${{ needs.tag.outputs.version }} --no-restore
@@ -55,7 +58,7 @@ jobs:
       run: dotnet nuget push ./artifacts/nuget/*.nupkg -k ${{ secrets.NUGET-API-KEY }} -s https://api.nuget.org/v3/index.json
 
     - name: Publish OctoConsole
-      run: dotnet publish src/OctoConsole/OctoConsole.csproj --configuration Release --output ./artifacts/octoconsole/ -p:Version=${{ needs.tag.outputs.version }}
+      run: dotnet publish src/OctoConsole/OctoConsole.csproj --configuration Release --output ./artifacts/octoconsole/ -p:Version=${{ needs.tag.outputs.version }} --no-restore
 
     - name: Upload OctoConsole
       uses: actions/upload-artifact@v2
@@ -64,7 +67,7 @@ jobs:
         path: ./artifacts/octoconsole/
 
     - name: Publish OctoPatch.DesktopClient
-      run: dotnet publish src/OctoPatch.DesktopClient/OctoPatch.DesktopClient.csproj --configuration Release --output ./artifacts/desktopclient/ -p:Version=${{ needs.tag.outputs.version }}
+      run: dotnet publish src/OctoPatch.DesktopClient/OctoPatch.DesktopClient.csproj --configuration Release --output ./artifacts/desktopclient/ -p:Version=${{ needs.tag.outputs.version }} --no-restore
 
     - name: Upload OctoPatch.DesktopClient
       uses: actions/upload-artifact@v2

--- a/.github/workflows/commonBuildAndTest.yml
+++ b/.github/workflows/commonBuildAndTest.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  tag:
     runs-on: ubuntu-latest
     
     outputs:
@@ -27,7 +27,7 @@ jobs:
         DEFAULT_BUMP: patch
 
   package:
-    needs: [build]
+    needs: [tag]
     runs-on: windows-latest
 
     steps:
@@ -37,25 +37,25 @@ jobs:
         dotnet-version: '3.1.x'
 
     - name: Install dependencies
-      run: dotnet restore
-      working-directory: src
+      run: dotnet restore --runtime win-x86 
+      working-directory: src/
 
     - name: Build
       run: dotnet build --configuration Release --no-restore
-      working-directory: src
+      working-directory: src/
 
     - name: Test
       run: dotnet test --no-restore --verbosity normal
-      working-directory: src
+      working-directory: src/
 
     - name: Create NuGet Package
-      run: dotnet pack src/OctoPatch/OctoPatch.csproj --configuration Release --output ./artifacts/nuget/ -p:Version=${{ needs.build.outputs.version }} --no-restore
+      run: dotnet pack src/OctoPatch/OctoPatch.csproj --configuration Release --output ./artifacts/nuget/ -p:Version=${{ needs.tag.outputs.version }} --no-restore
 
     - name: Publish NuGet Package
       run: dotnet nuget push ./artifacts/nuget/*.nupkg -k ${{ secrets.NUGET-API-KEY }} -s https://api.nuget.org/v3/index.json
 
     - name: Publish OctoConsole
-      run: dotnet publish src/OctoConsole/OctoConsole.csproj --configuration Release --runtime win-x86 --output ./artifacts/octoconsole/ -p:Version=${{ needs.build.outputs.version }}
+      run: dotnet publish src/OctoConsole/OctoConsole.csproj --configuration Release --output ./artifacts/octoconsole/ -p:Version=${{ needs.tag.outputs.version }}
 
     - name: Upload OctoConsole
       uses: actions/upload-artifact@v2
@@ -64,7 +64,7 @@ jobs:
         path: ./artifacts/octoconsole/
 
     - name: Publish OctoPatch.DesktopClient
-      run: dotnet publish src/OctoPatch.DesktopClient/OctoPatch.DesktopClient.csproj --configuration Release --runtime win-x86 --output ./artifacts/desktopclient/ -p:Version=${{ needs.build.outputs.version }}
+      run: dotnet publish src/OctoPatch.DesktopClient/OctoPatch.DesktopClient.csproj --configuration Release --output ./artifacts/desktopclient/ -p:Version=${{ needs.tag.outputs.version }}
 
     - name: Upload OctoPatch.DesktopClient
       uses: actions/upload-artifact@v2

--- a/.github/workflows/commonBuildAndTest.yml
+++ b/.github/workflows/commonBuildAndTest.yml
@@ -41,15 +41,15 @@ jobs:
 
     - name: Install dependencies
       run: dotnet restore --runtime win-x86 
-      working-directory: src\
+      working-directory: src
 
     - name: Build
       run: dotnet build --configuration Release --no-restore
-      working-directory: src\
+      working-directory: src
 
     - name: Test
       run: dotnet test --no-restore --verbosity normal
-      working-directory: src\
+      working-directory: src
 
     - name: Create NuGet Package
       run: dotnet pack src/OctoPatch/OctoPatch.csproj --configuration Release --output ./artifacts/nuget/ -p:Version=${{ needs.tag.outputs.version }} --no-restore

--- a/.github/workflows/commonBuildAndTest.yml
+++ b/.github/workflows/commonBuildAndTest.yml
@@ -8,21 +8,75 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+    
+    outputs:
+      version: ${{ steps.tag-action.outputs.new_tag }}
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0 # set the fetch-depth for actions/checkout@master to be sure you retrieve all commits to look for the semver commit message.
+
+    - name: Bump version and push tag
+      id: tag-action
+      uses: anothrNick/github-tag-action@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        DEFAULT_BUMP: patch
+
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.301
+        dotnet-version: '3.1.x'
+
     - name: Install dependencies
       run: dotnet restore
       working-directory: src
+
     - name: Build
       run: dotnet build --configuration Release --no-restore
       working-directory: src
+
     - name: Test
       run: dotnet test --no-restore --verbosity normal
       working-directory: src
+
+    - name: Create NuGet Package
+      run: dotnet pack src/OctoPatch/OctoPatch.csproj --configuration Release --output ./artifacts/nuget/ -p:Version=${{ steps.tag-action.outputs.new_tag }} --no-restore
+
+    - name: Publish NuGet Package
+      run: dotnet nuget push ./artifacts/nuget/*.nupkg -k ${{ secrets.NUGET-API-KEY }} -s https://api.nuget.org/v3/index.json
+
+  package:
+    needs: [build]
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '3.1.x'
+
+    - name: Publish OctoConsole
+      run: dotnet publish src/OctoConsole/OctoConsole.csproj --configuration Release --runtime win-x86 --output ./artifacts/octoconsole/ -p:Version=${{ needs.build.outputs.version }}
+
+    - name: Upload OctoConsole
+      uses: actions/upload-artifact@v2
+      with:
+        name: OctoConsole
+        path: ./artifacts/octoconsole/
+
+    - name: Publish OctoPatch.DesktopClient
+      run: dotnet publish src/OctoPatch.DesktopClient/OctoPatch.DesktopClient.csproj --configuration Release --runtime win-x86 --output ./artifacts/desktopclient/ -p:Version=${{ needs.build.outputs.version }}
+
+    - name: Upload OctoPatch.DesktopClient
+      uses: actions/upload-artifact@v2
+      with:
+        name: OctoPatch.DesktopClient
+        path: ./artifacts/desktopclient/
+       

--- a/.github/workflows/commonBuildAndTest.yml
+++ b/.github/workflows/commonBuildAndTest.yml
@@ -38,15 +38,15 @@ jobs:
 
     - name: Install dependencies
       run: dotnet restore --runtime win-x86 
-      working-directory: src
+      working-directory: src\
 
     - name: Build
       run: dotnet build --configuration Release --no-restore
-      working-directory: src
+      working-directory: src\
 
     - name: Test
       run: dotnet test --no-restore --verbosity normal
-      working-directory: src
+      working-directory: src\
 
     - name: Create NuGet Package
       run: dotnet pack src/OctoPatch/OctoPatch.csproj --configuration Release --output ./artifacts/nuget/ -p:Version=${{ needs.tag.outputs.version }} --no-restore

--- a/.github/workflows/commonBuildAndTest.yml
+++ b/.github/workflows/commonBuildAndTest.yml
@@ -31,6 +31,9 @@ jobs:
     runs-on: windows-latest
 
     steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:

--- a/src/OctoPatch.DesktopClient/OctoPatch.DesktopClient.csproj
+++ b/src/OctoPatch.DesktopClient/OctoPatch.DesktopClient.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\OctoPatch\src\OctoPatch\OctoPatch.csproj" />
+    <ProjectReference Include="..\OctoPatch\OctoPatch.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/OctoPatch.sln
+++ b/src/OctoPatch.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OctoConsole", "OctoConsole\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OctoPatch.Host", "OctoPatch.Host\OctoPatch.Host.csproj", "{F3E0E7E6-061B-42E2-BEC5-96584EF9C589}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OctoPatch.DesktopClient", "OctoPatch.DesktopClient\OctoPatch.DesktopClient.csproj", "{DCA000DE-4D53-4CCE-A02B-4233CD634978}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{F3E0E7E6-061B-42E2-BEC5-96584EF9C589}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F3E0E7E6-061B-42E2-BEC5-96584EF9C589}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F3E0E7E6-061B-42E2-BEC5-96584EF9C589}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DCA000DE-4D53-4CCE-A02B-4233CD634978}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DCA000DE-4D53-4CCE-A02B-4233CD634978}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DCA000DE-4D53-4CCE-A02B-4233CD634978}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DCA000DE-4D53-4CCE-A02B-4233CD634978}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/OctoPatch/OctoPatch.csproj
+++ b/src/OctoPatch/OctoPatch.csproj
@@ -1,7 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <Authors>Tom Wendel</Authors>
+    <PackageProjectUrl>https://github.com/AusLiebeZumCode/OctoPatch</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/AusLiebeZumCode/OctoPatch</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/AusLiebeZumCode/OctoPatch</PackageProjectUrl>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Der `OctoPatch.DesktopClient` war nicht in der Projektmappe eingetragen
Da der DesktopClient nur auf Windows baut, habe ich die Github Action dementsprechend umgebaut.

Bitte auch squashen @tomwendel 
requires #9 