### PR TITLE
Fixes wrong directory for nuget push

### DIFF
--- a/.github/workflows/commonBuildAndTest.yml
+++ b/.github/workflows/commonBuildAndTest.yml
@@ -55,6 +55,7 @@ jobs:
       run: dotnet pack src/OctoPatch/OctoPatch.csproj --configuration Release --output ./artifacts/nuget/ -p:Version=${{ needs.tag.outputs.version }} --no-restore
 
     - name: Publish NuGet Package
+      if: ${{ github.base_ref == 'refs/heads/master' || github.base_ref == 'refs/heads/main' }}
       working-directory: ./artifacts/nuget/
       run: dotnet nuget push *.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
 

--- a/.github/workflows/commonBuildAndTest.yml
+++ b/.github/workflows/commonBuildAndTest.yml
@@ -2,9 +2,9 @@ name: Common build and test
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, main ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, main ]
 
 jobs:
   tag:
@@ -55,7 +55,7 @@ jobs:
       run: dotnet pack src/OctoPatch/OctoPatch.csproj --configuration Release --output ./artifacts/nuget/ -p:Version=${{ needs.tag.outputs.version }} --no-restore
 
     - name: Publish NuGet Package
-      if: ${{ github.base_ref == 'refs/heads/master' || github.base_ref == 'refs/heads/main' }}
+      if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
       working-directory: ./artifacts/nuget/
       run: dotnet nuget push *.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
 

--- a/.github/workflows/commonBuildAndTest.yml
+++ b/.github/workflows/commonBuildAndTest.yml
@@ -55,7 +55,8 @@ jobs:
       run: dotnet pack src/OctoPatch/OctoPatch.csproj --configuration Release --output ./artifacts/nuget/ -p:Version=${{ needs.tag.outputs.version }} --no-restore
 
     - name: Publish NuGet Package
-      run: dotnet nuget push ./artifacts/nuget/*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
+      working-directory: ./artifacts/nuget/
+      run: dotnet nuget push *.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
 
     - name: Publish OctoConsole
       run: dotnet publish src/OctoConsole/OctoConsole.csproj --configuration Release --output ./artifacts/octoconsole/ -p:Version=${{ needs.tag.outputs.version }} --no-restore


### PR DESCRIPTION
* NuGet Push Ordner gefixt
* Build Script angepasst, damit es auf `master` und `main` läuft
* Nur NuGet Push Buildschritt machen, wenn es einen Commit auf master/main gab