### PR TITLE
Fix NuGet prerelease  version

### DIFF
--- a/.github/workflows/commonBuildAndTest.yml
+++ b/.github/workflows/commonBuildAndTest.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Create version string
       id: get-version
       shell: pwsh
-      run: echo "::set-output name=version::$(&{If($env:GITHUB_REF -eq 'refs/heads/develop') {'${{ steps.tag_action.outputs.new_tag }}' + '-' + $env:GITHUB_SHA.Substring(0, 7)} Else {'${{ steps.tag_action.outputs.new_tag }}'}})"
+      run: echo "::set-output name=version::$(&{If($env:GITHUB_REF -eq 'refs/heads/develop') {'${{ steps.tag_action.outputs.new_tag }}' + '--' + $env:GITHUB_SHA.Substring(0, 7)} Else {'${{ steps.tag_action.outputs.new_tag }}'}})"
 
     - name: Print version string
       run: echo ${{ steps.get-version.outputs.version }}


### PR DESCRIPTION
Somehow the nuget.org server does not want `0.0.1-1234567` . So we provide now ``0.0.1--1234567``. https://nugettoolsdev.azurewebsites.net/5.6.0/parse-version?version=0.0.1-1234567