### PR TITLE
build(sonarcloud): add static code analysis

### DIFF
--- a/.github/workflows/commonBuildAndTest.yml
+++ b/.github/workflows/commonBuildAndTest.yml
@@ -2,144 +2,176 @@ name: Common build and test
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [main, develop]
   pull_request:
-    branches: [ main, develop ]
+    branches: [main, develop]
 
 jobs:
   tag:
     runs-on: ubuntu-latest
-    
+
     outputs:
       versionwithoutsha: ${{ steps.tag_action.outputs.new_tag }}
       version: ${{ steps.get-version.outputs.version }}
       release: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' }}
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0 # set the fetch-depth for actions/checkout to be sure you retrieve all commits to look for the semver commit message.
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # set the fetch-depth for actions/checkout to be sure you retrieve all commits to look for the semver commit message.
 
-    - name: Bump version and push tag
-      id: tag_action
-      uses: anothrNick/github-tag-action@master
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        DEFAULT_BUMP: patch
-        RELEASE_BRANCHES: 'main,develop'
+      - name: Bump version and push tag
+        id: tag_action
+        uses: anothrNick/github-tag-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEFAULT_BUMP: patch
+          RELEASE_BRANCHES: "main,develop"
 
-    # When we are on develop we want a prerelease
-    - name: Create version string
-      id: get-version
-      shell: pwsh
-      run: echo "::set-output name=version::$('${{ steps.tag_action.outputs.new_tag }}' + $(&{If($env:GITHUB_REF -eq 'refs/heads/develop') {'-pre'} Else {''}}))"
+      # When we are on develop we want a prerelease
+      - name: Create version string
+        id: get-version
+        shell: pwsh
+        run: echo "::set-output name=version::$('${{ steps.tag_action.outputs.new_tag }}' + $(&{If($env:GITHUB_REF -eq 'refs/heads/develop') {'-pre'} Else {''}}))"
 
-    - name: Print version string
-      run: echo ${{ steps.get-version.outputs.version }}
+      - name: Print version string
+        run: echo ${{ steps.get-version.outputs.version }}
+
+  scan:
+    env:
+      SONAR_HOST_URL: "https://sonarcloud.io"
+      SONAR_PROJECT_KEY: "AusLiebeZumCode_OctoPatch"
+      SONAR_ORGANIZATION_KEY: "ausliebezumcode"
+
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: "3.1.x"
+
+      - name: Add sonarscanner
+        run: dotnet tool install --global dotnet-sonarscanner --version 4.10.0
+
+      - name: Scan
+        run: |
+          dotnet sonarscanner begin /k:"${{env.SONAR_PROJECT_KEY}}" /o:"${{env.SONAR_ORGANIZATION_KEY}}" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="${{ env.SONAR_HOST_URL }}"
+          dotnet build OctoPatch.sln
+          dotnet test OctoPatch.sln --collect "Code Coverage"
+          dotnet sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
 
   build:
     needs: [tag]
     runs-on: windows-latest
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '3.1.x'
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: "3.1.x"
 
-    - name: Install dependencies
-      run: dotnet restore --runtime win-x86 
+      - name: Install dependencies
+        run: dotnet restore --runtime win-x86
 
-    - name: Build
-      run: dotnet build --configuration Release --no-restore
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
 
-    - name: Test
-      run: dotnet test --no-restore --verbosity normal
+      - name: Test
+        run: dotnet test --no-restore --verbosity normal
 
-    - name: Create NuGet Package (OctoPatch)
-      run: dotnet pack src/Core/OctoPatch/OctoPatch.csproj --configuration Release --output ./artifacts/nuget -p:Version=${{ needs.tag.outputs.version }} --no-restore
+      - name: Create NuGet Package (OctoPatch)
+        run: dotnet pack src/Core/OctoPatch/OctoPatch.csproj --configuration Release --output ./artifacts/nuget -p:Version=${{ needs.tag.outputs.version }} --no-restore
 
-    - name: Create NuGet Package (OctoPatch.Core)
-      run: dotnet pack src/Core/OctoPatch.Core/OctoPatch.Core.csproj --configuration Release --output ./artifacts/nuget -p:Version=${{ needs.tag.outputs.version }} --no-restore
+      - name: Create NuGet Package (OctoPatch.Core)
+        run: dotnet pack src/Core/OctoPatch.Core/OctoPatch.Core.csproj --configuration Release --output ./artifacts/nuget -p:Version=${{ needs.tag.outputs.version }} --no-restore
 
-    - name: Create NuGet Package (OctoPatch.Server)
-      run: dotnet pack src/Core/OctoPatch.Server/OctoPatch.Server.csproj --configuration Release --output ./artifacts/nuget -p:Version=${{ needs.tag.outputs.version }} --no-restore
+      - name: Create NuGet Package (OctoPatch.Server)
+        run: dotnet pack src/Core/OctoPatch.Server/OctoPatch.Server.csproj --configuration Release --output ./artifacts/nuget -p:Version=${{ needs.tag.outputs.version }} --no-restore
 
-    - name: Create NuGet Package (OctoPatch.Client)
-      run: dotnet pack src/Core/OctoPatch.Client/OctoPatch.Client.csproj --configuration Release --output ./artifacts/nuget -p:Version=${{ needs.tag.outputs.version }} --no-restore
+      - name: Create NuGet Package (OctoPatch.Client)
+        run: dotnet pack src/Core/OctoPatch.Client/OctoPatch.Client.csproj --configuration Release --output ./artifacts/nuget -p:Version=${{ needs.tag.outputs.version }} --no-restore
 
-    - name: Create NuGet Package (OctoPatch.Plugin.Midi)
-      run: dotnet pack src/Plugins/OctoPatch.Plugin.Midi/OctoPatch.Plugin.Midi.csproj --configuration Release --output ./artifacts/nuget -p:Version=${{ needs.tag.outputs.version }} --no-restore
+      - name: Create NuGet Package (OctoPatch.Plugin.Midi)
+        run: dotnet pack src/Plugins/OctoPatch.Plugin.Midi/OctoPatch.Plugin.Midi.csproj --configuration Release --output ./artifacts/nuget -p:Version=${{ needs.tag.outputs.version }} --no-restore
 
-    - name: Publish NuGet Packages
-      if: ${{ github.repository == 'AusLiebeZumCode/OctoPatch' && needs.tag.outputs.release == 'true' }}
-      working-directory: ./artifacts/nuget
-      run: dotnet nuget push *.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
+      - name: Publish NuGet Packages
+        if: ${{ github.repository == 'AusLiebeZumCode/OctoPatch' && needs.tag.outputs.release == 'true' }}
+        working-directory: ./artifacts/nuget
+        run: dotnet nuget push *.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
 
-    - name: Publish OctoConsole
-      run: dotnet publish src/Applications/OctoConsole/OctoConsole.csproj --configuration Release --output ./artifacts/octoconsole/ -p:Version=${{ needs.tag.outputs.version }} --no-restore
+      - name: Publish OctoConsole
+        run: dotnet publish src/Applications/OctoConsole/OctoConsole.csproj --configuration Release --output ./artifacts/octoconsole/ -p:Version=${{ needs.tag.outputs.version }} --no-restore
 
-    - name: Create artifacts folder
-      shell: pwsh
-      run: New-Item -ItemType Directory -Path C:\artifacts -Force
+      - name: Create artifacts folder
+        shell: pwsh
+        run: New-Item -ItemType Directory -Path C:\artifacts -Force
 
-    - name: Zip OctoConsole Files
-      shell: pwsh
-      run: Compress-Archive -Path ./artifacts/octoconsole/* -DestinationPath C:\artifacts\OctoConsole.zip
+      - name: Zip OctoConsole Files
+        shell: pwsh
+        run: Compress-Archive -Path ./artifacts/octoconsole/* -DestinationPath C:\artifacts\OctoConsole.zip
 
-    - name: Upload OctoConsole
-      uses: actions/upload-artifact@v2
-      with:
-        name: OctoConsole
-        path: ./artifacts/octoconsole/ # Use folder instead of .zip https://github.com/actions/upload-artifact#zipped-artifact-downloads
+      - name: Upload OctoConsole
+        uses: actions/upload-artifact@v2
+        with:
+          name: OctoConsole
+          path: ./artifacts/octoconsole/ # Use folder instead of .zip https://github.com/actions/upload-artifact#zipped-artifact-downloads
 
-    - name: Publish OctoPatch.DesktopClient
-      run: dotnet publish src/Applications/OctoPatch.DesktopClient/OctoPatch.DesktopClient.csproj --configuration Release --output ./artifacts/desktopclient/ -p:Version=${{ needs.tag.outputs.version }} --no-restore
+      - name: Publish OctoPatch.DesktopClient
+        run: dotnet publish src/Applications/OctoPatch.DesktopClient/OctoPatch.DesktopClient.csproj --configuration Release --output ./artifacts/desktopclient/ -p:Version=${{ needs.tag.outputs.version }} --no-restore
 
-    - name: Zip OctoPatch.DesktopClient Files
-      shell: pwsh
-      run: Compress-Archive -Path ./artifacts/desktopclient/* -DestinationPath C:\artifacts\OctoPatch.DesktopClient.zip
+      - name: Zip OctoPatch.DesktopClient Files
+        shell: pwsh
+        run: Compress-Archive -Path ./artifacts/desktopclient/* -DestinationPath C:\artifacts\OctoPatch.DesktopClient.zip
 
-    - name: Upload OctoPatch.DesktopClient
-      uses: actions/upload-artifact@v2
-      with:
-        name: OctoPatch.DesktopClient
-        path: ./artifacts/desktopclient/ # Use folder instead of .zip https://github.com/actions/upload-artifact#zipped-artifact-downloads
+      - name: Upload OctoPatch.DesktopClient
+        uses: actions/upload-artifact@v2
+        with:
+          name: OctoPatch.DesktopClient
+          path: ./artifacts/desktopclient/ # Use folder instead of .zip https://github.com/actions/upload-artifact#zipped-artifact-downloads
 
-    - name: Create Release
-      if: ${{ needs.tag.outputs.release == 'true' }}
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
-      with:
-        tag_name: ${{ needs.tag.outputs.versionwithoutsha }} # Use Version without sha because thats what we have as a tag on git
-        release_name: Release ${{ needs.tag.outputs.versionwithoutsha }}
-        draft: false
-        prerelease: ${{ github.ref != 'refs/heads/main' }}
-          
-    - name: Upload Release Asset OctoConsole
-      if: ${{ needs.tag.outputs.release == 'true' }}
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-        asset_path: C:\artifacts\OctoConsole.zip
-        asset_name: OctoConsole.zip
-        asset_content_type: application/zip
+      - name: Create Release
+        if: ${{ needs.tag.outputs.release == 'true' }}
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ needs.tag.outputs.versionwithoutsha }} # Use Version without sha because thats what we have as a tag on git
+          release_name: Release ${{ needs.tag.outputs.versionwithoutsha }}
+          draft: false
+          prerelease: ${{ github.ref != 'refs/heads/main' }}
 
-    - name: Upload Release Asset OctoPatch.DesktopClient
-      if: ${{ needs.tag.outputs.release == 'true' }}
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-        asset_path: C:\artifacts\OctoPatch.DesktopClient.zip
-        asset_name: OctoPatch.DesktopClient.zip
-        asset_content_type: application/zip
+      - name: Upload Release Asset OctoConsole
+        if: ${{ needs.tag.outputs.release == 'true' }}
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path: C:\artifacts\OctoConsole.zip
+          asset_name: OctoConsole.zip
+          asset_content_type: application/zip
+
+      - name: Upload Release Asset OctoPatch.DesktopClient
+        if: ${{ needs.tag.outputs.release == 'true' }}
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path: C:\artifacts\OctoPatch.DesktopClient.zip
+          asset_name: OctoPatch.DesktopClient.zip
+          asset_content_type: application/zip

--- a/.github/workflows/commonBuildAndTest.yml
+++ b/.github/workflows/commonBuildAndTest.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Print version string
         run: echo ${{ steps.get-version.outputs.version }}
 
+
   scan:
     env:
       SONAR_HOST_URL: "https://sonarcloud.io"


### PR DESCRIPTION
Damit die Analyse richtig funktioniert, musst du im Github Repository von OctoPatch noch ein Secret für den Zugriff auf die Sonarcloud hinterlegen. Dieses Secret muss ```SONAR_TOKEN``` heißen.

Du erhälst es direkt bei der Konfiguration einer manuellen Scan-Konfiguration. Falls du das Projekt nachträglich einrichtest findest du es wie folgt:
Administration >> Analysis Method >> Manually - Follow the tutorial >>

![image](https://user-images.githubusercontent.com/363497/90989725-5d3a9280-e59c-11ea-8ca8-663939112c1c.png)

Wenn du Probleme hast, melde dich einfach! Die Analyse erzeugt zunächst keinen Abbruch des Builds, wenn sie nicht korrekt läuft.