### PR TITLE
Change Serilog.Sinks.RollingFile to Serilog.Sinks.File

### DIFF
--- a/src/Applications/OctoConsole/OctoConsole.csproj
+++ b/src/Applications/OctoConsole/OctoConsole.csproj
@@ -12,7 +12,7 @@
 	<ItemGroup>
 	  <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />
 	  <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-	  <PackageReference Include="Serilog.Sinks.RollingFile" Version="3.3.0" />
+	  <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
 	  <PackageReference Include="Serilog.Sinks.Seq" Version="4.0.0" />
 	</ItemGroup>
 

--- a/src/Applications/OctoConsole/Program.cs
+++ b/src/Applications/OctoConsole/Program.cs
@@ -11,7 +11,7 @@ namespace OctoConsole
             Log.Logger = new LoggerConfiguration()
               .Enrich.FromLogContext()
               .WriteTo.Console()
-              .WriteTo.RollingFile("./logs/")
+              .WriteTo.File("./logs/.log", rollingInterval: RollingInterval.Day, rollOnFileSizeLimit: true)
               .WriteTo.Seq("http://localhost:5341")
               .MinimumLevel.Debug()
               .CreateLogger();

--- a/src/Applications/OctoPatch.DesktopClient/App.xaml.cs
+++ b/src/Applications/OctoPatch.DesktopClient/App.xaml.cs
@@ -15,7 +15,7 @@ namespace OctoPatch.DesktopClient
             Log.Logger = new LoggerConfiguration()
               .Enrich.FromLogContext()
               .WriteTo.Console()
-              .WriteTo.RollingFile("./logs/")
+              .WriteTo.File("./logs/.log", rollingInterval: RollingInterval.Day, rollOnFileSizeLimit: true)
               .WriteTo.Seq("http://localhost:5341")
               .MinimumLevel.Debug()
               .CreateLogger();

--- a/src/Applications/OctoPatch.DesktopClient/OctoPatch.DesktopClient.csproj
+++ b/src/Applications/OctoPatch.DesktopClient/OctoPatch.DesktopClient.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="3.1.7" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-    <PackageReference Include="Serilog.Sinks.RollingFile" Version="3.3.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="4.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
- RollingFile is outdated and should not be used
- log files will roll every day or when size of 1GB exceeded
- Use `.log` as file ending for log files